### PR TITLE
Bug Fix - Issue #6821

### DIFF
--- a/src/prefect/cli/orion.py
+++ b/src/prefect/cli/orion.py
@@ -124,7 +124,7 @@ async def start(
                 command=[
                     "uvicorn",
                     "--app-dir",
-                    str(prefect.__module_path__.parent),
+                    "../..",
                     "--factory",
                     "prefect.orion.api.server:create_app",
                     "--host",


### PR DESCRIPTION
https://github.com/PrefectHQ/prefect/issues/6821

## Summary
- Bug fix suggestion for https://github.com/PrefectHQ/prefect/issues/6821
- Prefect Orion fails to start on Windows when there is a space in Prefect package's path

## Bug Fix
- `str(prefect.__module_path__.parent)` represents the absolute path. Prefect Orion fails to start in Windows OS if the directory path contains spaces.
```
Error: Got unexpected extra argument (prefect.orion.api.server:create_app)
Orion stopped!
```

- `"../.."` represents relative path. **This solves the problem.**
